### PR TITLE
Adds OID set method support

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for SNMP-Extension-PassPersist
 
+0.07.2  2015.03.20 - Thomas Pérennou
+        [FEATURE] Adds OID set method support
+
 0.07    2013.01.07 - Sebastien Aperghis-Tramoni (SAPER)
         [FEATURE] CPAN-RT#82362: Add support for counter64 (Pete Bristow).
         [TESTS] Skip some tests under Win32.

--- a/eg/synopsis-passpersist.pl
+++ b/eg/synopsis-passpersist.pl
@@ -1,19 +1,23 @@
-#!perl
+#!/usr/bin/perl
 use strict;
 use SNMP::Extension::PassPersist;
 
 # create the object
 my $extsnmp = SNMP::Extension::PassPersist->new(
+    backend_init    => \&init_tree,
     backend_collect => \&update_tree,
 );
 
 # run the program
 $extsnmp->run;
 
+sub init_tree {
+    $extsnmp->add_oid_entry(".1.2.42.2", "string" , "the answer");
+}
+
 sub update_tree {
     my ($self) = @_;
 
     # add a few OID entries
     $self->add_oid_entry(".1.2.42.1", "integer", 42);
-    $self->add_oid_entry(".1.2.42.2", "string" , "the answer");
 }


### PR DESCRIPTION
This pull request adds support to snmpset command and several bug fixes:
- crash when a request occurred when agent fork for an external shell command (close backend IO),
- agent waits for command input while already buffered in input (only sysread is compatible with select).
